### PR TITLE
Fix leap year definition in calendar.widget

### DIFF
--- a/calendar.widget/calendar.widget.coffee
+++ b/calendar.widget/calendar.widget.coffee
@@ -87,7 +87,7 @@ updateBody: (rows, table) ->
   year = today[2]
 
   lengths = [31, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30]
-  if year%4 == 0
+  if year%4 == 0 and (year%100 != 0 or year%400 == 0)
     lengths[2] = 29
 
   for week, i in rows


### PR DESCRIPTION
Leap year is now defined as year divisible by 4, but not divisible by 100, unless divisible by 400. Previously incorrect code checked for divisible by 4 only.